### PR TITLE
Bump cookie dependency to ^0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "cookie": "^0.5.0"
+    "cookie": "^0.7.1"
   },
   "devDependencies": {
     "esbuild": "^0.17.17"


### PR DESCRIPTION
To fix vulnerability https://github.com/jshttp/cookie/pull/167

Closes https://github.com/bundled-es-modules/cookie/issues/2