### PR TITLE
chore: use @ossjs/release for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    branches:
+      - [main]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v3
+        with:
+          always-auth: true
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup Git
+        run: |
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "actions@github.com"
+
+      - run: npm ci
+      - run: npm test
+
+      - run: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "dev": "node --watch dev.js",
-    "build": "esbuild source.js --bundle --format=esm --outfile=index.js"
+    "build": "esbuild source.js --bundle --format=esm --outfile=index.js",
+    "release": "release publish"
   },
   "keywords": [],
   "files": [
@@ -25,6 +26,7 @@
     "cookie": "^0.7.1"
   },
   "devDependencies": {
+    "@ossjs/release": "^0.8.1",
     "esbuild": "^0.17.17"
   }
 }

--- a/release.config.json
+++ b/release.config.json
@@ -1,0 +1,8 @@
+{
+  "profiles": [
+    {
+      "name": "latest",
+      "use": "npm publish"
+    }
+  ]
+}


### PR DESCRIPTION
This adds https://github.com/ossjs/release as the release automation tool for the package. Also adds a GitHub workflows to have the releases running on each merge to `main`.

## Todo

- [ ] Add a [`CI_GITHUB_TOKEN`](https://github.com/ossjs/release?tab=readme-ov-file#generate-github-personal-access-token) as the repo secret (follow the link to set it up with the correct permissions).
- [ ] Add an `NPM_TOKEN` token as the repo secret (the token must have automation permission on NPM to be able to publish packages). 